### PR TITLE
Add "ultrasound" and "distance" to the description

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 # Toit Package File.
 name: hc_sr04
-description: Driver for the HC-SR04 ultrasonic ranging module.
+description: Driver for the HC-SR04 ultrasonic ranging module, an ultrasound distance sensor.
 environment:
   sdk: ^2.0.0-alpha.1


### PR DESCRIPTION
This way a `pkg search distance` can find the driver.