### PR TITLE
Update GPIO usage for SDK 2.0 alpha 196

### DIFF
--- a/examples/example.toit
+++ b/examples/example.toit
@@ -2,13 +2,10 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the EXAMPLES_LICENSE file.
 
-import gpio
 import hc-sr04
 
 main:
-  echo := gpio.Pin.in 19
-  trigger := gpio.Pin.out 18
-  driver := hc-sr04.Driver --echo=echo --trigger=trigger
+  driver := hc-sr04.Driver --echo=19 --trigger=18
 
   while true:
     print "The distance is: $driver.read-distance mm"

--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,7 @@ name: hc-sr04
 description: Driver for the HC-SR04 ultrasonic ranging module, an ultrasound distance
   sensor.
 environment:
-  sdk: ^2.0.0-alpha.180
+  sdk: ^2.0.0-alpha.194.1
 dependencies:
   sensors:
     url: github.com/toitware/toit-sensors

--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,7 @@ name: hc-sr04
 description: Driver for the HC-SR04 ultrasonic ranging module, an ultrasound distance
   sensor.
 environment:
-  sdk: ^2.0.0-alpha.194.1
+  sdk: ^2.0.0-alpha.196
 dependencies:
   sensors:
     url: github.com/toitware/toit-sensors

--- a/src/driver.toit
+++ b/src/driver.toit
@@ -44,8 +44,15 @@ class Driver:
     $trigger pin for output.
 
   It uses two RMT channels.
+
+  The pins are GPIO numbers. Passing a $gpio.Pin is deprecated; provide the integer
+    GPIO number instead.
   */
-  constructor --echo/gpio.Pin --trigger/gpio.Pin:
+  // __TYPE-MIGRATION__ echo: gpio.Pin. Deprecated. Provide an integer instead.
+  // __TYPE-MIGRATION__ echo: int
+  // __TYPE-MIGRATION__ trigger: gpio.Pin. Deprecated. Provide an integer instead.
+  // __TYPE-MIGRATION__ trigger: int
+  constructor --echo/any --trigger/any:
     trigger_ = rmt.Out trigger --resolution=1_000_000
     echo_ = rmt.In echo --resolution=(80_000_000 / 233)
 

--- a/src/provider.toit
+++ b/src/provider.toit
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an MIT-style license that can be found
 // in the LICENSE file.
 
-import gpio
 import i2c
 import sensors.providers
 
@@ -13,22 +12,10 @@ MAJOR ::= 1
 MINOR ::= 0
 
 class Sensor_ implements providers.DistanceSensor-v1:
-  trigger_/gpio.Pin? := null
-  echo_/gpio.Pin? := null
   sensor_/hc-sr04.Driver? := null
 
   constructor --trigger/int --echo/int:
-    is-exception := true
-    try:
-      trigger_ = gpio.Pin trigger
-      echo_ = gpio.Pin echo
-      sensor_ = hc-sr04.Driver --trigger=trigger_ --echo=echo_
-      is-exception = false
-    finally:
-      if is-exception:
-        if sensor_: sensor_.close
-        if trigger_: trigger_.close
-        if echo_: echo_.close
+    sensor_ = hc-sr04.Driver --trigger=trigger --echo=echo
 
   distance-read -> int?:
     return sensor_.read-distance
@@ -37,12 +24,6 @@ class Sensor_ implements providers.DistanceSensor-v1:
     if sensor_:
       sensor_.close
       sensor_ = null
-    if trigger_:
-      trigger_.close
-      trigger_ = null
-    if echo_:
-      echo_.close
-      echo_ = null
 
 /**
 Installs the HC-SR04 sensor.


### PR DESCRIPTION
## Summary

- migrate peripheral construction to pass integer GPIO numbers
- require Toit SDK `^2.0.0-alpha.196`
- include related package publishing updates where needed

This is part of the SDK 196 peripheral API migration.
